### PR TITLE
Add dark mode toggle

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -8,7 +8,8 @@ body {
   font-family: 'Poppins', sans-serif; /* Fuente más moderna */
   line-height: 1.6;
   overflow-wrap: break-word;
-}/* Mejoras en variables globales */
+}
+/* Mejoras en variables globales */
 :root {
   --primary-color: #f5a002e5;
   --secondary-color: #ffe395; 
@@ -18,12 +19,47 @@ body {
   --shadow: 0 5px 15px rgba(0,0,0,0.1);
   --transition: all 0.3s ease;
   --border-radius: 10px;
+
 }
+/* Dark theme variables */
+
+[data-theme="dark"] {
+  --store-background-color: #222;
+  --store-background-color-contrast-25: rgba(255,255,255,0.25);
+  --store-background-color-contrast-50: rgba(255,255,255,0.5);
+  --background-color: #222;
+  --text-color: #f5f5f5;
+  --primary-color: #ff9800;
+  --secondary-color: #444;
+}
+
 
 /* Mejoras en el diseño base */
 body {
   font-family: 'Poppins', sans-serif; /* Fuente más moderna */
   line-height: 1.6;
+.theme-toggle {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 1000;
+  background: var(--primary-color);
+  color: var(--primary-color-contrast, #fff);
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}
+
+.theme-toggle:hover {
+  opacity: 0.8;
+}
+
   color: var(--text-color);
 }
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -570,3 +570,22 @@ function updateProgressCircles() {
 
 updateProgressCircles();
 
+
+// Dark mode toggle
+document.addEventListener("DOMContentLoaded", () => {
+  const button = document.getElementById("theme-toggle");
+  if (!button) return;
+  const root = document.documentElement;
+  const stored = localStorage.getItem("theme");
+  if (stored) root.setAttribute("data-theme", stored);
+  button.addEventListener("click", () => {
+    const current = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
+    root.setAttribute("data-theme", current);
+    localStorage.setItem("theme", current);
+    const icon = button.querySelector("i");
+    if (icon) {
+      icon.classList.toggle("fa-moon", current === "light");
+      icon.classList.toggle("fa-sun", current === "dark");
+    }
+  });
+});

--- a/templates/layout.liquid
+++ b/templates/layout.liquid
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js" lang="{{ languages.first.locale }}" xmlns="http://www.w3.org/1999/xhtml">
+<html data-theme="light" class="no-js" lang="{{ languages.first.locale }}" xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>{{ page_title }}</title>
     <meta name="description" content="{{ meta_description }}">
@@ -84,6 +84,7 @@
 
     {% render 'store_whatsapp' %}
 
+    <button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema"><i class="fas fa-moon"></i></button>
     {{ options.body_code }}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- enable dark mode by adding `data-theme` variables and toggle styles
- add toggle button in layout and update html tag
- handle theme toggle in `main.js`

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_685c081cf1708332964c4754b05b2a0b